### PR TITLE
Power query

### DIFF
--- a/EPPlus/EPPlus.MultiTarget.csproj
+++ b/EPPlus/EPPlus.MultiTarget.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net35;net40</TargetFrameworks>
-    <AssemblyVersion>4.5.3.7</AssemblyVersion>
-    <FileVersion>4.5.3.7</FileVersion>
-    <Version>4.5.3.7</Version>
+    <AssemblyVersion>4.5.3.8</AssemblyVersion>
+    <FileVersion>4.5.3.8</FileVersion>
+    <Version>4.5.3.8</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://licenses.nuget.org/LGPL-3.0-or-later</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/JanKallman/EPPlus</PackageProjectUrl>

--- a/EPPlus/EPPlus.csproj
+++ b/EPPlus/EPPlus.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Connection\ExcelConnections.cs" />
     <Compile Include="Connection\ExcelDatabaseProperties.cs" />
     <Compile Include="Drawing\Chart\ExcelChartDataTable.cs" />
+    <Compile Include="ExcelDataMashup.cs" />
     <Compile Include="FontSize.cs" />
     <Compile Include="DataValidation\Contracts\IExcelDataValidation.cs" />
     <Compile Include="DataValidation\Contracts\IExcelDataValidationAny.cs" />

--- a/EPPlus/ExcelDataMashup.cs
+++ b/EPPlus/ExcelDataMashup.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using OfficeOpenXml.Packaging;
+
+namespace OfficeOpenXml
+{
+    public class ExcelDataMashup : XmlHelper
+    {
+        internal ExcelDataMashup(ExcelPackage package, XmlNamespaceManager nameSpaceManager) : base(nameSpaceManager)
+        {
+            var item1Uri = new Uri("/customXml/item1.xml", UriKind.Relative);
+            if (!package.Package.PartExists(item1Uri)) return;
+            var item1Xml = new XmlDocument();
+            LoadXmlSafe(item1Xml, package.Package.GetPart(item1Uri).GetStream());
+            TopNode = item1Xml.DocumentElement;
+            byte[] dataMashup = Convert.FromBase64String(TopNode.InnerText);
+            GetSection1M(dataMashup);
+        }
+
+        private void GetSection1M(byte[] dataMashupBytes)
+        {
+            //Only reading section1.M from packaging parts
+            int packagingPartsLength = BitConverter.ToUInt16(dataMashupBytes.Skip(4).Take(4).ToArray(), 0);
+            byte[] packagingPartsBytes = dataMashupBytes.Skip(8).Take(packagingPartsLength).ToArray();
+
+            using (MemoryStream packagingPartsStream = new MemoryStream(packagingPartsBytes))
+            {
+                var packagingParts = new ZipPackage(packagingPartsStream);
+                ZipPackagePart section1M = packagingParts.GetPart(new Uri("/Formulas/Section1.m", UriKind.Relative));
+                if (section1M == null) return;
+                using (var reader = new StreamReader(section1M.GetStream())) PowerQueryFormulas = reader.ReadToEnd();
+            }
+        }
+        public string PowerQueryFormulas { get; private set; }
+    }
+}

--- a/EPPlus/ExcelWorkbook.cs
+++ b/EPPlus/ExcelWorkbook.cs
@@ -132,6 +132,9 @@ namespace OfficeOpenXml
 	    internal FormulaParserManager _parserManager;
         internal CellStore<List<Token>> _formulaTokens;
         internal ExcelConnections _connections;
+        internal ExcelDataMashup _dataMashup;
+
+        public ExcelDataMashup DataMashup => _dataMashup ?? (_dataMashup = new ExcelDataMashup(_package, _namespaceManager));
 
         /// <summary>
         /// Provides access to connections


### PR DESCRIPTION
EPPlus is now able to extract used power queries. If available, this file is located in \custom1\item1.xml, which needs to be decoded and unzipped. For more information see [MS-QDEFF](https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-qdeff/27b1dd1e-7de8-45d9-9c84-dfcc7a802e37)