### PR TITLE
Update sheetname single quotes

### DIFF
--- a/EPPlus/EPPlus.MultiTarget.csproj
+++ b/EPPlus/EPPlus.MultiTarget.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyVersion>4.5.3.10</AssemblyVersion>
-    <FileVersion>4.5.3.10</FileVersion>
-    <Version>4.5.3.10</Version>
+    <AssemblyVersion>4.5.3.11</AssemblyVersion>
+    <FileVersion>4.5.3.11</FileVersion>
+    <Version>4.5.3.11</Version>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0;net35;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://licenses.nuget.org/LGPL-3.0-or-later</PackageLicenseUrl>

--- a/EPPlus/ExcelAddress.cs
+++ b/EPPlus/ExcelAddress.cs
@@ -407,7 +407,7 @@ namespace OfficeOpenXml
 
         public string GetWorksheetNameEscaped()
         {
-            return Regex.IsMatch(_ws, RegexConstants.SheetNameSingleQuotes) ? $"'{_ws.Replace("'", "''")}'" : _ws;
+            return Regex.IsMatch(_ws, RegexConstants.SheetNameSingleQuotes, RegexOptions.IgnorePatternWhitespace) ? $"'{_ws.Replace("'", "''")}'" : _ws;
         }
         #endregion
         protected ExcelCellAddress _start = null;

--- a/EPPlus/FormulaParsing/Utilities/RegexConstants.cs
+++ b/EPPlus/FormulaParsing/Utilities/RegexConstants.cs
@@ -41,9 +41,11 @@ namespace OfficeOpenXml.FormulaParsing.Utilities
         //Changed JK 26/2-2013
         public const string ExcelAddress = @"^(('[^/\\?*\[\]]{1,31}'|[A-Za-z_]{1,31})!)?[\$]{0,1}([A-Z]|[A-Z]{1,3}[\$]{0,1}[1-9]{1}[0-9]{0,7})(\:({0,1}[A-Z]|[A-Z]{1,3}[\$]{0,1}[1-9]{1}[0-9]{0,7})){0,1}$";
         //public const string ExcelAddress = @"^([\$]{0,1}([A-Z]{1,3}[\$]{0,1}[0-9]{1,7})(\:([\$]{0,1}[A-Z]{1,3}[\$]{0,1}[0-9]{1,7}){0,1})|([\$]{0,1}[A-Z]{1,3}\:[\$]{0,1}[A-Z]{1,3})|([\$]{0,1}[0-9]{1,7}\:[\$]{0,1}[0-9]{1,7}))$";
-        public const string SheetNameSingleQuotes = @"^[A-Z]{1,3}[1-9]{1}[0-9]{0,7}$|^R-?\d*C-?\d*$|[\s()'$,;\-{}!]";
+        public static readonly string SheetNameSingleQuotes = $@"^{ColumnPattern}{RowPattern}$|^R-?\d*C-?\d*$|[\s()'$,;\-{{}}!]|^\d";
         public const string Boolean = @"^(true|false)$";
         public const string Decimal = @"^[0-9]+\.[0-9]+$";
         public const string Integer = @"^[0-9]+$";
+        public static readonly string ColumnPattern = @"[A-Z]{1,2} | [A-W][A-Z]{1,2} | X[A-E][A-Z] | XF[A-D]";
+        public static readonly string RowPattern = @"[1-9]\d{0,5} | 10[0-3]\d{4} | 104[0-7]\d{3} | 1048[0-4]\d{2} | 10485[0-6]\d | 104857[0-6]";
     }
 }


### PR DESCRIPTION
Sheetnames starting with a number will now contain quotes.
Sheetnames as celladdress has been updated (XFE1 and A1048577 will no longer contain quotes)
