### PR TITLE
Whitespaces added in token separator provider.

### DIFF
--- a/EPPlus/EPPlus.MultiTarget.csproj
+++ b/EPPlus/EPPlus.MultiTarget.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyVersion>4.5.3.12</AssemblyVersion>
-    <FileVersion>4.5.3.12</FileVersion>
-    <Version>4.5.3.12</Version>
+    <AssemblyVersion>4.5.3.13</AssemblyVersion>
+    <FileVersion>4.5.3.13</FileVersion>
+    <Version>4.5.3.13</Version>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0;net35;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://licenses.nuget.org/LGPL-3.0-or-later</PackageLicenseUrl>

--- a/EPPlus/FormulaParsing/LexicalAnalysis/TokenSeparatorProvider.cs
+++ b/EPPlus/FormulaParsing/LexicalAnalysis/TokenSeparatorProvider.cs
@@ -67,6 +67,7 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
             _tokens.Add("]", new Token("]", TokenType.ClosingBracket));
             _tokens.Add("%", new Token("%", TokenType.Percent));
             _tokens.Add("\n", new Token("\n", TokenType.NewLine));
+            _tokens.Add(" ", new Token(" ", TokenType.WhiteSpace));
         }
 
         IDictionary<string, Token> ITokenSeparatorProvider.Tokens

--- a/EPPlus/FormulaParsing/LexicalAnalysis/TokenType.cs
+++ b/EPPlus/FormulaParsing/LexicalAnalysis/TokenType.cs
@@ -65,6 +65,7 @@ namespace OfficeOpenXml.FormulaParsing.LexicalAnalysis
         Null,
         Unrecognized,
         ExcelAddressR1C1,
-        NewLine
+        NewLine,
+        WhiteSpace
     }
 }


### PR DESCRIPTION
It seems that the ToR1C1 does not handle whitespaces correctly. It ignores usual usages of whitespaces. It transforms `=C1 + C2` into `=R[-4]C[2]+R[-3]C[2]`. It also does not handle the intersect operator correctly. It transforms =`SUM(B:B)` into =`SUM(C[1])`, but `=SUM(B:B 2:2)` into `=SUM(C[1]:B 2:2)`. Adding whitespace as token separator fixes this problem. 

Whitespaces can occur in 5 ways.
1) External file names. But during ToR1C1, the filenumber is used instead of the actual filename.
2) A sheet name can contain whitespaces. But EPPlus already contains a sheetname handler which adds the whitespace separator token to the sheetname.
3) A string can contain whitespaces. The StringHandler handles this.
4) A intersect operator.
5) Adding whitespaces just to change how a formula looks `=A1+A2 <=> =A1 + A2`.