### PR TITLE
Invalid defined names

### DIFF
--- a/EPPlus/EPPlus.MultiTarget.csproj
+++ b/EPPlus/EPPlus.MultiTarget.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyVersion>4.5.3.13</AssemblyVersion>
-    <FileVersion>4.5.3.13</FileVersion>
-    <Version>4.5.3.13</Version>
+    <AssemblyVersion>4.5.3.14</AssemblyVersion>
+    <FileVersion>4.5.3.14</FileVersion>
+    <Version>4.5.3.14</Version>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0;net35;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://licenses.nuget.org/LGPL-3.0-or-later</PackageLicenseUrl>

--- a/EPPlus/ExcelWorkbook.cs
+++ b/EPPlus/ExcelWorkbook.cs
@@ -194,102 +194,109 @@ namespace OfficeOpenXml
 			if (nl != null)
 			{
 				foreach (XmlElement elem in nl)
-				{ 
-					string fullAddress = elem.InnerText;
+				{
+                    try
+                    {
+                        string fullAddress = elem.InnerText;
 
-					int localSheetID;
-					ExcelWorksheet nameWorksheet;
-					
-                    if(!int.TryParse(elem.GetAttribute("localSheetId"), NumberStyles.Number, CultureInfo.InvariantCulture, out localSheetID))
-					{
-						localSheetID = -1;
-						nameWorksheet=null;
-					}
-					else
-					{
-						nameWorksheet=Worksheets[localSheetID + _package._worksheetAdd];
-					}
+                        int localSheetID;
+                        ExcelWorksheet nameWorksheet;
 
-					var addressType = ExcelAddressBase.IsValid(fullAddress, out _);
-					ExcelRangeBase range;
-					ExcelNamedRange namedRange;
+                        if (!int.TryParse(elem.GetAttribute("localSheetId"), NumberStyles.Number, CultureInfo.InvariantCulture, out localSheetID))
+                        {
+                            localSheetID = -1;
+                            nameWorksheet = null;
+                        }
+                        else
+                        {
+                            nameWorksheet = Worksheets[localSheetID + _package._worksheetAdd];
+                        }
 
-					if (fullAddress.IndexOf("[") == 0)
-					{
-						int start = fullAddress.IndexOf("[");
-						int end = fullAddress.IndexOf("]", start);
-						if (start >= 0 && end >= 0)
-						{
+                        var addressType = ExcelAddressBase.IsValid(fullAddress, out _);
+                        ExcelRangeBase range;
+                        ExcelNamedRange namedRange;
 
-							string externalIndex = fullAddress.Substring(start + 1, end - start - 1);
-							int index;
-							if (int.TryParse(externalIndex, NumberStyles.Any, CultureInfo.InvariantCulture, out index))
-							{
-								if (index > 0 && index <= _externalReferences.Count)
-								{
-									fullAddress = fullAddress.Substring(0, start) + "[" + _externalReferences[index - 1] + "]" + fullAddress.Substring(end + 1);
-								}
-							}
-						}
-					}
+                        if (fullAddress.IndexOf("[") == 0)
+                        {
+                            int start = fullAddress.IndexOf("[");
+                            int end = fullAddress.IndexOf("]", start);
+                            if (start >= 0 && end >= 0)
+                            {
 
-					if (addressType == ExcelAddressBase.AddressType.Invalid || addressType == ExcelAddressBase.AddressType.InternalName || addressType == ExcelAddressBase.AddressType.ExternalName || addressType==ExcelAddressBase.AddressType.Formula || addressType==ExcelAddressBase.AddressType.ExternalAddress)    //A value or a formula
-					{
-						double value;
-						range = new ExcelRangeBase(this, nameWorksheet, elem.GetAttribute("name"), true);
-						if (nameWorksheet == null)
-						{
-							namedRange = _names.Add(elem.GetAttribute("name"), range);
-						}
-						else
-						{
-							namedRange = nameWorksheet.Names.Add(elem.GetAttribute("name"), range);
-						}
-						
-						if (Utils.ConvertUtil._invariantCompareInfo.IsPrefix(fullAddress, "\"")) //String value
-						{
-							namedRange.NameValue = fullAddress.Substring(1,fullAddress.Length-2);
-						}
-						else if (double.TryParse(fullAddress, NumberStyles.Number, CultureInfo.InvariantCulture, out value))
-						{
-							namedRange.NameValue = value;
-						}
-						else
-						{
-                            //if (addressType == ExcelAddressBase.AddressType.ExternalAddress || addressType == ExcelAddressBase.AddressType.ExternalName)
-                            //{
-                            //    var r = new ExcelAddress(fullAddress);
-                            //    namedRange.NameFormula = '\'[' + r._wb
-                            //}
-                            //else
-                            //{
+                                string externalIndex = fullAddress.Substring(start + 1, end - start - 1);
+                                int index;
+                                if (int.TryParse(externalIndex, NumberStyles.Any, CultureInfo.InvariantCulture, out index))
+                                {
+                                    if (index > 0 && index <= _externalReferences.Count)
+                                    {
+                                        fullAddress = fullAddress.Substring(0, start) + "[" + _externalReferences[index - 1] + "]" + fullAddress.Substring(end + 1);
+                                    }
+                                }
+                            }
+                        }
+
+                        if (addressType == ExcelAddressBase.AddressType.Invalid || addressType == ExcelAddressBase.AddressType.InternalName || addressType == ExcelAddressBase.AddressType.ExternalName || addressType == ExcelAddressBase.AddressType.Formula || addressType == ExcelAddressBase.AddressType.ExternalAddress)    //A value or a formula
+                        {
+                            double value;
+                            range = new ExcelRangeBase(this, nameWorksheet, elem.GetAttribute("name"), true);
+                            if (nameWorksheet == null)
+                            {
+                                namedRange = _names.Add(elem.GetAttribute("name"), range);
+                            }
+                            else
+                            {
+                                namedRange = nameWorksheet.Names.Add(elem.GetAttribute("name"), range);
+                            }
+
+                            if (ConvertUtil._invariantCompareInfo.IsPrefix(fullAddress, "\"")) //String value
+                            {
+                                namedRange.NameValue = fullAddress.Substring(1, fullAddress.Length - 2);
+                            }
+                            else if (double.TryParse(fullAddress, NumberStyles.Number, CultureInfo.InvariantCulture, out value))
+                            {
+                                namedRange.NameValue = value;
+                            }
+                            else
+                            {
+                                //if (addressType == ExcelAddressBase.AddressType.ExternalAddress || addressType == ExcelAddressBase.AddressType.ExternalName)
+                                //{
+                                //    var r = new ExcelAddress(fullAddress);
+                                //    namedRange.NameFormula = '\'[' + r._wb
+                                //}
+                                //else
+                                //{
                                 namedRange.NameFormula = fullAddress;
-                            //}
-						}
-					}
-					else
-					{
-						ExcelAddress addr = new ExcelAddress(fullAddress, _package, null);
-						if (localSheetID > -1)
-						{
-							if (string.IsNullOrEmpty(addr._ws))
-							{
-								namedRange = Worksheets[localSheetID + _package._worksheetAdd].Names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, Worksheets[localSheetID + _package._worksheetAdd], fullAddress, false));
-							}
-							else
-							{
-								namedRange = Worksheets[localSheetID + _package._worksheetAdd].Names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, Worksheets[addr._ws], fullAddress, false));
-							}
-						}
-						else
-						{
-							var ws = Worksheets[addr._ws];
-							namedRange = _names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, ws, fullAddress, false));
-						}
-					}
-					if (elem.GetAttribute("hidden") == "1" && namedRange != null) namedRange.IsNameHidden = true;
-					if(!string.IsNullOrEmpty(elem.GetAttribute("comment"))) namedRange.NameComment=elem.GetAttribute("comment");
-				}
+                                //}
+                            }
+                        }
+                        else
+                        {
+                            ExcelAddress addr = new ExcelAddress(fullAddress, _package, null);
+                            if (localSheetID > -1)
+                            {
+                                if (string.IsNullOrEmpty(addr._ws))
+                                {
+                                    namedRange = Worksheets[localSheetID + _package._worksheetAdd].Names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, Worksheets[localSheetID + _package._worksheetAdd], fullAddress, false));
+                                }
+                                else
+                                {
+                                    namedRange = Worksheets[localSheetID + _package._worksheetAdd].Names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, Worksheets[addr._ws], fullAddress, false));
+                                }
+                            }
+                            else
+                            {
+                                var ws = Worksheets[addr._ws];
+                                namedRange = _names.Add(elem.GetAttribute("name"), new ExcelRangeBase(this, ws, fullAddress, false));
+                            }
+                        }
+                        if (elem.GetAttribute("hidden") == "1" && namedRange != null) namedRange.IsNameHidden = true;
+                        if (!string.IsNullOrEmpty(elem.GetAttribute("comment"))) namedRange.NameComment = elem.GetAttribute("comment");
+                    }
+                    catch (Exception e)
+                    {
+                        // Quickfix: Hidden named ranges that references worksheets which do not exist will not be added to all defined names.
+                    }
+                }
 			}
 		}
         #region Worksheets


### PR DESCRIPTION
Sometimes defined names stored in xml can be invalid (most likely due to not well written macros). This quick fix negates those errors.